### PR TITLE
Update ProductInfo.md

### DIFF
--- a/Resources/ProductInfo.md
+++ b/Resources/ProductInfo.md
@@ -1,92 +1,92 @@
 | Product | Home Page |
 | --- | --- |
-| Legion | [http://legion.stanford.edu](http://legion.stanford.edu/) |
-| ROSE | [https://github.com/rose-compiler](https://github.com/rose-compiler) |
-| Kokkos | [https://github.com/kokkos](https://github.com/kokkos) |
-| DARMA | [https://github.com/darma-tasking](https://github.com/darma-tasking) |
-| Global Arrays | [http://hpc.pnl.gov/globalarrays/](http://hpc.pnl.gov/globalarrays/) |
-| RAJA | [https://github.com/LLNL/RAJA](https://github.com/LLNL/RAJA) |
-| CHAI | [https://github.com/LLNL/CHAI](https://github.com/LLNL/CHAI) |
-| Umpire |   |
-| MPICH | [http://www.mpich.org](http://www.mpich.org/) |
-| PaRSEC | [http://icl.utk.edu/parsec/](http://icl.utk.edu/parsec/) |
-| Open MPI | [https://www.open-mpi.org/](https://www.open-mpi.org/) |
-| PMIx | [https://pmix.org/](https://pmix.org/) |
-| GEOPM | [https://geopm.github.io/](https://geopm.github.io/) |
-| LLVM OpenMP compiler | [https://github.com/SOLLVE](https://github.com/SOLLVE) |
-| OpenMP V \& V Suite | [https://bitbucket.org/crpl\_cisc/sollve\_vv/src](https://bitbucket.org/crpl_cisc/sollve_vv/src) |
-| BOLT | [https://github.com/pmodels/argobots](https://github.com/pmodels/argobots) |
-| UPC++ | [http://upcxx.lbl.gov](http://upcxx.lbl.gov/) |
-| GASNet-EX | [http://gasnet.lbl.gov](http://gasnet.lbl.gov/) |
-| Qthreads | [https://github.com/Qthreads](https://github.com/Qthreads) |
-| SICM | [https://confluence.exascaleproject.org/display/STSS07](https://confluence.exascaleproject.org/display/STSS07) |
-| QUO | [https://github.com/lanl/libquo](https://github.com/lanl/libquo) |
-| Kitsune | [https://github.com/lanl/kitsune](https://github.com/lanl/kitsune) |
-| SCR | [https://github.com/llnl/scr](https://github.com/llnl/scr) |
-| Caliper | [https://github.com/llnl/caliper](https://github.com/llnl/caliper) |
-| mpiFileUtils | [https://github.com/hpc/mpifileutils](https://github.com/hpc/mpifileutils) |
-| Gotcha | [http://github.com/llnl/gotcha](http://github.com/llnl/gotcha) |
-| TriBITS | [https://tribits.org](https://tribits.org/) |
-| Exascale Code Geneneration Toolkit |
-| PAPI | [http://icl.utk.edu/exa-papi/](http://icl.utk.edu/exa-papi/) |
-| CHiLL Autotuning Compiler |
-| Search using Random Forests (SuRF) |
-| HPCToolkit | [http://hpctoolkit.org](http://hpctoolkit.org/) |
-| The Dyninst Binary Tools Suite | [http://www.paradyn.org](http://www.paradyn.org/) |
-| Tau | [http://www.cs.uoregon.edu/research/tau](http://www.cs.uoregon.edu/research/tau) |
-| Papyrus | [https://ft.ornl.gov/research/papyrus](https://ft.ornl.gov/research/papyrus) |
-| openarc | [https://ft.ornl.gov/research/openarc](https://ft.ornl.gov/research/openarc) |
-| LLVM | [http://llvm.org/](http://llvm.org/) |
-| Program Database Toolkit (PDT) | [https://www.cs.uoregon.edu/research/pdt/home.php](https://www.cs.uoregon.edu/research/pdt/home.php) |
-| xSDK | [https://xsdk.info](https://xsdk.info/) |
-| hypre | [http://www.llnl.gov/casc/hypre](http://www.llnl.gov/casc/hypre) |
-| FleCSI | [http://www.flecsi.org](http://www.flecsi.org/) |
-| MFEM | [http://mfem.org/](http://mfem.org/) |
-| Kokkoskernels | [https://github.com/kokkos/kokkos-kernels/](https://github.com/kokkos/kokkos-kernels/) |
-| Trilinos | [https://github.com/trilinos/Trilinos](https://github.com/trilinos/Trilinos) |
-| SUNDIALS | [https://computation.llnl.gov/projects/sundials](https://computation.llnl.gov/projects/sundials) |
-| PETSc/TAO | [http://www.mcs.anl.gov/petsc](http://www.mcs.anl.gov/petsc) |
-| libEnsemble | [https://github.com/Libensemble/libensemble](https://github.com/Libensemble/libensemble) |
-| STRUMPACK | [http://portal.nersc.gov/project/sparse/strumpack/](http://portal.nersc.gov/project/sparse/strumpack/) |
-| SuperLU | [http://crd-legacy.lbl.gov/~xiaoye/SuperLU/](http://crd-legacy.lbl.gov/~xiaoye/SuperLU/) |
-| ForTrilinos | [https://trilinos.github.io/ForTrilinos/](https://trilinos.github.io/ForTrilinos/) |
-| SLATE | [http://icl.utk.edu/slate/](http://icl.utk.edu/slate/) |
-| MAGMA-sparse | [https://bitbucket.org/icl/magma](https://bitbucket.org/icl/magma) |
-| DTK | [https://github.com/ORNL-CEES/DataTransferKit](https://github.com/ORNL-CEES/DataTransferKit) |
-| Tasmanian | [http://tasmanian.ornl.gov/](http://tasmanian.ornl.gov/) |
-| HXHIM | [http://github.com/hpc/hxhim.git](http://github.com/hpc/hxhim.git) |
-| Cinema | [https://datascience.lanl.gov/Cinema.html](https://datascience.lanl.gov/Cinema.html) |
-| MarFS | [https://github.com/mar-file-system/marfs](https://github.com/mar-file-system/marfs) |
-| GUFI (The Grand Unified File Index) | [https://github.com/mar-file-system/GUFI](https://github.com/mar-file-system/GUFI) |
-| Siboka |   |
-| ROVER |   |
-| C2C |   |
-| TuckerMPI |   |
-| ParaView | [https://www.paraview.org/](https://www.paraview.org/) |
-| Catalyst | [https://www.paraview.org/in-situ/](https://www.paraview.org/in-situ/) |
-| VTK-m | [http://m.vtk.org](http://m.vtk.org/) |
-| FAODEL | [https://github.com/faodel/faodel](https://github.com/faodel/faodel) |
-| IOSS | [https://github.com/gsjaardema/seacas](https://github.com/gsjaardema/seacas) |
-| VeloC | [https://github.com/ECP-VeloC/VELOC](https://github.com/ECP-VeloC/VELOC) |
-| SZ | [https://github.com/disheng222/SZ](https://github.com/disheng222/SZ) |
-| UnifyCR | [https://github.com/LLNL/UnifyCR](https://github.com/LLNL/UnifyCR) |
-| HDF5 | [https://www.hdfgroup.org/downloads/](https://www.hdfgroup.org/downloads/) |
 | ADIOS | [https://github.com/ornladios/ADIOS2](https://github.com/ornladios/ADIOS2) |
-| Parallel netCDF | [http://cucis.ece.northwestern.edu/projects/PnetCDF/](http://cucis.ece.northwestern.edu/projects/PnetCDF/) |
-| Darshan | [http://www.mcs.anl.gov/research/projects/darshan/](http://www.mcs.anl.gov/research/projects/darshan/) |
-| ROMIO | [http://www.mcs.anl.gov/projects/romio/](http://www.mcs.anl.gov/projects/romio/) |
-| Mercury (part of Mochi suite) | [http://www.mcs.anl.gov/research/projects/mochi/](http://www.mcs.anl.gov/research/projects/mochi/) |
-| zfp | [https://github.com/LLNL/zfp](https://github.com/LLNL/zfp) |
-| VisIt | [https://wci.llnl.gov/simulation/computer-codes/visit](https://wci.llnl.gov/simulation/computer-codes/visit) |
+| AML | [https://xgitlab.cels.anl.gov/argo/aml](https://xgitlab.cels.anl.gov/argo/aml) |
+| ArgoContainers | [https://xgitlab.cels.anl.gov/argo/containers](https://xgitlab.cels.anl.gov/argo/containers) |
 | ASCENT | [https://github.com/Alpine-DAV/ascent](https://github.com/Alpine-DAV/ascent) |
 | BEE |   |
-| FSEFI |   |
-| Spack | [https://github.com/spack/spack](https://github.com/spack/spack) |
-| Sonar |   |
-| Secure JupyterHub |   |
-| Kitten Lightweight Kernel | [https://github.com/HobbesOSR/kitten](https://github.com/HobbesOSR/kitten) |
-| AML | [ https://xgitlab.cels.anl.gov/argo/aml](https://xgitlab.cels.anl.gov/argo/aml) |
-| ArgoContainers | [ https://xgitlab.cels.anl.gov/argo/containers](https://xgitlab.cels.anl.gov/argo/containers) |
-| COOLR | [ https://github.com/coolr-hpc](https://github.com/coolr-hpc) |
-| NRM | [https://xgitlab.cels.anl.gov/argo/nrm](https://xgitlab.cels.anl.gov/argo/nrm) |
+| BOLT | [https://github.com/pmodels/argobots](https://github.com/pmodels/argobots) |
+| C2C |   |
+| Caliper | [https://github.com/llnl/caliper](https://github.com/llnl/caliper) |
+| Catalyst | [https://www.paraview.org/in-situ/](https://www.paraview.org/in-situ/) |
+| CHAI | [https://github.com/LLNL/CHAI](https://github.com/LLNL/CHAI) |
+| CHiLL Autotuning Compiler |
+| Cinema | [https://datascience.lanl.gov/Cinema.html](https://datascience.lanl.gov/Cinema.html) |
+| COOLR | [https://github.com/coolr-hpc](https://github.com/coolr-hpc) |
+| DARMA | [https://github.com/darma-tasking](https://github.com/darma-tasking) |
+| Darshan | [https://www.mcs.anl.gov/research/projects/darshan/](https://www.mcs.anl.gov/research/projects/darshan/) |
+| DTK | [https://github.com/ORNL-CEES/DataTransferKit](https://github.com/ORNL-CEES/DataTransferKit) |
+| Exascale Code Geneneration Toolkit |
+| FAODEL | [https://github.com/faodel/faodel](https://github.com/faodel/faodel) |
 | Flang/LLVM Fortran compiler | [http://www.flang-compiler.org](http://www.flang-compiler.org/) |
+| FleCSI | [http://www.flecsi.org](http://www.flecsi.org/) |
+| ForTrilinos | [https://trilinos.github.io/ForTrilinos/](https://trilinos.github.io/ForTrilinos/) |
+| FSEFI |   |
+| GASNet-EX | [https://gasnet.lbl.gov](https://gasnet.lbl.gov/) |
+| GEOPM | [https://geopm.github.io/](https://geopm.github.io/) |
+| Global Arrays | [https://hpc.pnl.gov/globalarrays/](https://hpc.pnl.gov/globalarrays/) |
+| Gotcha | [https://github.com/llnl/gotcha](https://github.com/llnl/gotcha) |
+| GUFI (The Grand Unified File Index) | [https://github.com/mar-file-system/GUFI](https://github.com/mar-file-system/GUFI) |
+| HDF5 | [https://www.hdfgroup.org/downloads/](https://www.hdfgroup.org/downloads/) |
+| HPCToolkit | [http://hpctoolkit.org](http://hpctoolkit.org/) |
+| HXHIM | [http://github.com/hpc/hxhim.git](http://github.com/hpc/hxhim.git) |
+| hypre | [https://www.llnl.gov/casc/hypre](https://www.llnl.gov/casc/hypre) |
+| IOSS | [https://github.com/gsjaardema/seacas](https://github.com/gsjaardema/seacas) |
+| Kitsune | [https://github.com/lanl/kitsune](https://github.com/lanl/kitsune) |
+| Kitten Lightweight Kernel | [https://github.com/HobbesOSR/kitten](https://github.com/HobbesOSR/kitten) |
+| Kokkos | [https://github.com/kokkos](https://github.com/kokkos) |
+| Kokkoskernels | [https://github.com/kokkos/kokkos-kernels/](https://github.com/kokkos/kokkos-kernels/) |
+| Legion | [https://legion.stanford.edu](https://legion.stanford.edu/) |
+| libEnsemble | [https://github.com/Libensemble/libensemble](https://github.com/Libensemble/libensemble) |
+| LLVM | [https://llvm.org/](https://llvm.org/) |
+| LLVM OpenMP compiler | [https://github.com/SOLLVE](https://github.com/SOLLVE) |
+| MAGMA-sparse | [https://bitbucket.org/icl/magma](https://bitbucket.org/icl/magma) |
+| MarFS | [https://github.com/mar-file-system/marfs](https://github.com/mar-file-system/marfs) |
+| Mercury (part of Mochi suite) | [https://www.mcs.anl.gov/research/projects/mochi/](https://www.mcs.anl.gov/research/projects/mochi/) |
+| MFEM | [https://mfem.org/](https://mfem.org/) |
+| MPICH | [https://www.mpich.org](https://www.mpich.org/) |
+| mpiFileUtils | [https://github.com/hpc/mpifileutils](https://github.com/hpc/mpifileutils) |
+| NRM | [https://xgitlab.cels.anl.gov/argo/nrm](https://xgitlab.cels.anl.gov/argo/nrm) |
+| Open MPI | [https://www.open-mpi.org/](https://www.open-mpi.org/) |
+| openarc | [https://ft.ornl.gov/research/openarc](https://ft.ornl.gov/research/openarc) |
+| OpenMP V \& V Suite | [https://bitbucket.org/crpl\_cisc/sollve\_vv/src](https://bitbucket.org/crpl_cisc/sollve_vv/src) |
+| PAPI | [https://icl.utk.edu/exa-papi/](https://icl.utk.edu/exa-papi/) |
+| Papyrus | [https://csmd.ornl.gov/project/papyrus](https://csmd.ornl.gov/project/papyrus) |
+| Parallel netCDF | [http://cucis.ece.northwestern.edu/projects/PnetCDF/](http://cucis.ece.northwestern.edu/projects/PnetCDF/) |
+| ParaView | [https://www.paraview.org/](https://www.paraview.org/) |
+| PaRSEC | [https://icl.utk.edu/parsec/](https://icl.utk.edu/parsec/) |
+| PETSc/TAO | [https://www.mcs.anl.gov/petsc](https://www.mcs.anl.gov/petsc) |
+| PMIx | [https://pmix.org/](https://pmix.org/) |
+| Program Database Toolkit (PDT) | [https://www.cs.uoregon.edu/research/pdt/home.php](https://www.cs.uoregon.edu/research/pdt/home.php) |
+| Qthreads | [https://github.com/Qthreads](https://github.com/Qthreads) |
+| QUO | [https://github.com/lanl/libquo](https://github.com/lanl/libquo) |
+| RAJA | [https://github.com/LLNL/RAJA](https://github.com/LLNL/RAJA) |
+| ROMIO | [https://www.mcs.anl.gov/projects/romio/](https://www.mcs.anl.gov/projects/romio/) |
+| ROSE | [https://github.com/rose-compiler](https://github.com/rose-compiler) |
+| ROVER |   |
+| SCR | [https://github.com/llnl/scr](https://github.com/llnl/scr) |
+| Search using Random Forests (SuRF) |
+| Secure JupyterHub |   |
+| Siboka |   |
+| SICM | [https://confluence.exascaleproject.org/display/STSS07](https://confluence.exascaleproject.org/display/STSS07) |
+| SLATE | [https://icl.utk.edu/slate/](https://icl.utk.edu/slate/) |
+| Sonar |   |
+| Spack | [https://github.com/spack/spack](https://github.com/spack/spack) |
+| STRUMPACK | [https://portal.nersc.gov/project/sparse/strumpack/](https://portal.nersc.gov/project/sparse/strumpack/) |
+| SUNDIALS | [https://computation.llnl.gov/projects/sundials](https://computation.llnl.gov/projects/sundials) |
+| SuperLU | [https://portal.nersc.gov/project/sparse/superlu/](https://portal.nersc.gov/project/sparse/superlu/) |
+| SZ | [https://github.com/disheng222/SZ](https://github.com/disheng222/SZ) |
+| Tasmanian | [https://tasmanian.ornl.gov/](https://tasmanian.ornl.gov/) |
+| Tau | [https://www.cs.uoregon.edu/research/tau](https://www.cs.uoregon.edu/research/tau) |
+| The Dyninst Binary Tools Suite | [http://www.paradyn.org](http://www.paradyn.org/) |
+| TriBITS | [https://tribits.org](https://tribits.org/) |
+| Trilinos | [https://github.com/trilinos/Trilinos](https://github.com/trilinos/Trilinos) |
+| TuckerMPI |   |
+| Umpire |   |
+| UnifyCR | [https://github.com/LLNL/UnifyCR](https://github.com/LLNL/UnifyCR) |
+| UPC++ | [http://upcxx.lbl.gov](http://upcxx.lbl.gov/) |
+| VeloC | [https://github.com/ECP-VeloC/VELOC](https://github.com/ECP-VeloC/VELOC) |
+| VisIt | [https://wci.llnl.gov/simulation/computer-codes/visit](https://wci.llnl.gov/simulation/computer-codes/visit) |
+| VTK-m | [http://m.vtk.org](http://m.vtk.org/) |
+| xSDK | [https://xsdk.info](https://xsdk.info/) |
+| zfp | [https://github.com/LLNL/zfp](https://github.com/LLNL/zfp) |


### PR DESCRIPTION
Sort A-Z for easy search. Delete extra space after "[" in: AML, ArgoContainers, COOLR. Add secure "s" in http for the following projects verified to have that secure connection component: Darshan,  GASNet-EX,  Global Arrays,  Gotcha, hypre, Legion, LLVM, Mercury, MFEM, MPICH, PAPI, PaRSEC,  PETSc/TAO, ROMIO, SLATE, STRUMPACK, Tasmanian, Tau.
NOTES: 
- Link to HXHIM (http://github.com/hpc/hxhim.git) does not work. No replacement link found.
- Link to Papyrus (https://ft.ornl.gov/research/papyrus) did not work so it was replaced by https://csmd.ornl.gov/project/papyrus (basically, just replacing "ft" by "csmd" at the beginning).
- Link to SuperLU (http://crd-legacy.lbl.gov/~xiaoye/SuperLU/) is redirecting to another page. Link updated to https://portal.nersc.gov/project/sparse/superlu/ after email approval from Sherry Li (SuperLU POC).