### PR TITLE
When proposing edits redirect user to the source code

### DIFF
--- a/_includes/e4s-page-actions.html
+++ b/_includes/e4s-page-actions.html
@@ -81,7 +81,7 @@ Please describe the problem with this page:
 
   <!-- Open this page in GitHub editor (will prompt to fork if needed) -->
   <a class="btn btn--e4s"
-     href="{{ repo_url }}/edit/master/{{ page.path }}"
+     href="{{ repo_url }}/blob/master/{{ page.path }}"
      target="_blank" rel="noopener">
     Propose page edits
   </a>


### PR DESCRIPTION
I think it is more valuable to point to the source code and let the users select "edit" themselves because newcomers would otherwise be prompted to immediately fork the repo before they can see the source.